### PR TITLE
chore: run multiple tc-go versions on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,8 @@ jobs:
     parameters:
       go-version:
         type: string
+      tcgo-version:
+        type: string
     steps:
       - run:
           name: Install GVM
@@ -35,6 +37,13 @@ jobs:
             go version
       - checkout # checkout source code
       - go/load-cache # Load cached Go modules.
+
+      - run:
+          name: Use testcontainers-go@<< parameters.tcgo-version >>
+          command: |
+            go get github.com/testcontainers/testcontainers-go/modules/compose@<< parameters.tcgo-version >>
+            go get github.com/testcontainers/testcontainers-go@<< parameters.tcgo-version >>
+
       - go/mod-download # Run 'go mod download'.
       - go/save-cache # Save Go modules to cache.
       - go/test: # Runs 'go test ./...' but includes extensive parameterization for finer tuning.
@@ -49,3 +58,4 @@ workflows:
           matrix:
             parameters:
               go-version: ["1.21.7", "1.22.3"]
+              tcgo-version: ["v0.31.0", "main"]


### PR DESCRIPTION
Run latest release and latest commit on main on CircleCI
