### PR TITLE
chore: run tests in Testcontainers Cloud

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,12 @@ jobs:
           failfast: true
           race: true
 
+commands:
+  clean_up_workspace:
+    steps:
+      - run: rm -rf * || true
+      - run: rm -rf .* || true
+
 workflows:
   build-and-test:
     jobs:
@@ -67,7 +73,8 @@ workflows:
       - tests:
           name: "Testcontainers Cloud"
           pre-steps:
-           - tcc/setup
+            - clean_up_workspace
+            - tcc/setup
           matrix:
             parameters:
               go-version: ["1.22.3"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ workflows:
               go-version: ["1.21.7", "1.22.3"]
               tcgo-version: ["v0.31.0", "main"]
       - tests:
+          name: "Testcontainers Cloud"
           pre-steps:
            - tcc/setup
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,14 @@ jobs:
             curl -sL -o ~/gvmbin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.5.2/gvm-linux-amd64
             chmod +x ~/gvmbin/gvm
             echo 'export PATH=$PATH:~/gvmbin' >> "$BASH_ENV"
+
       - run:
           name: Install Go
           command: |
             eval "$(gvm << parameters.go-version >>)"
             echo 'eval "$(gvm << parameters.go-version >>)"' >> "$BASH_ENV"
             go version
+
       - checkout # checkout source code
       - go/load-cache # Load cached Go modules.
 
@@ -47,6 +49,7 @@ jobs:
 
       - go/mod-download # Run 'go mod download'.
       - go/save-cache # Save Go modules to cache.
+
       - go/test: # Runs 'go test ./...' but includes extensive parameterization for finer tuning.
           covermode: atomic
           failfast: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,6 @@ workflows:
               go-version: ["1.21.7", "1.22.3"]
               tcgo-version: ["v0.31.0", "main"]
       - tests:
-          name: "Testcontainers Cloud"
           pre-steps:
            - tcc/setup
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       tcgo-version:
         type: string
       run-on-tcc:
-        type: bool
+        type: boolean
     steps:
       - checkout # checkout source code
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ workflows:
           name: "Testcontainers Cloud"
           pre-steps:
            - tcc/setup
-          parameters:
-            go-version: ["1.22.3"]
-            tcgo-version: ["main"]
+          matrix:
+            parameters:
+              go-version: ["1.22.3"]
+              tcgo-version: ["main"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ jobs:
         type: string
       tcgo-version:
         type: string
-      tcc:
+      run-on-tcc:
         type: bool
     steps:
       - checkout # checkout source code
 
       - when:
-          condition: <<parameters.tcc>>
+          condition: << parameters.run-on-tcc >>
           steps:
             - tcc/setup
 
@@ -77,7 +77,7 @@ workflows:
             parameters:
               go-version: ["1.21.7", "1.22.3"]
               tcgo-version: ["v0.31.0", "main"]
-              tcc: [false]
+              run-on-tcc: [false]
       - tests:
           name: "Testcontainers Cloud"
           pre-steps:
@@ -86,4 +86,4 @@ workflows:
             parameters:
               go-version: ["1.22.3"]
               tcgo-version: ["main"]
-              tcc: [true]
+              run-on-tcc: [true]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,15 @@ jobs:
         type: string
       tcgo-version:
         type: string
+      tcc:
+        type: bool
     steps:
       - checkout # checkout source code
+
+      - when:
+          condition: <<parameters.tcc>>
+          steps:
+            - tcc/setup
 
       - run:
           name: Install GVM
@@ -70,12 +77,13 @@ workflows:
             parameters:
               go-version: ["1.21.7", "1.22.3"]
               tcgo-version: ["v0.31.0", "main"]
+              tcc: [false]
       - tests:
           name: "Testcontainers Cloud"
           pre-steps:
             - clean_up_workspace
-            - tcc/setup
           matrix:
             parameters:
               go-version: ["1.22.3"]
               tcgo-version: ["main"]
+              tcc: [true]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ workflows:
               go-version: ["1.21.7", "1.22.3"]
               tcgo-version: ["v0.31.0", "main"]
       - tests:
-          name: "Testcontainer Cloud"
+          name: "Testcontainers Cloud"
           pre-steps:
            - tcc/setup
           parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ jobs:
       tcgo-version:
         type: string
     steps:
+      - checkout # checkout source code
+
       - run:
           name: Install GVM
           command: |
@@ -38,7 +40,6 @@ jobs:
             echo 'eval "$(gvm << parameters.go-version >>)"' >> "$BASH_ENV"
             go version
 
-      - checkout # checkout source code
       - go/load-cache # Load cached Go modules.
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ version: 2.1
 
 orbs:
   go: circleci/go@1.11.0
+  tcc: atomicjar/testcontainers-cloud-orb@0.1.0
 
 executors:
  machine_executor_amd64:
@@ -59,3 +60,10 @@ workflows:
             parameters:
               go-version: ["1.21.7", "1.22.3"]
               tcgo-version: ["v0.31.0", "main"]
+      - tests:
+          name: "Testcontainer Cloud"
+          pre-steps:
+           - tcc/setup
+          parameters:
+            go-version: ["1.22.3"]
+            tcgo-version: ["main"]


### PR DESCRIPTION
Includes the TCC orb, and repeats the existing job, but for just one Go version and the main branch. This new job first setups the TCC configuration. A secret has been created in the project, with the TCC token for the service account.
